### PR TITLE
Add preserve form data in local storage

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -345,7 +345,9 @@ const showModal = () => {
 showModal();
 
 const form = document.forms.contactForm;
+const nameInput = form.fullname;
 const emailInput = form.email;
+const messageInput = form.message;
 const formErrors = document.querySelector('.form-errors');
 
 const validateEmail = () => {
@@ -365,3 +367,29 @@ form.addEventListener('submit', (e) => {
   e.preventDefault();
   validateEmail();
 });
+
+const formData = {
+  fullname: '',
+  email: '',
+  message: '',
+};
+
+const setLocalData = () => {
+  localStorage.setItem('formData', JSON.stringify(formData));
+};
+
+form.addEventListener('change', () => {
+  formData.fullname = nameInput.value;
+  formData.email = emailInput.value;
+  formData.message = messageInput.value;
+  setLocalData();
+});
+
+const getLocalData = () => {
+  const localFormData = JSON.parse(localStorage.getItem('formData'));
+  nameInput.value = localFormData.fullname;
+  emailInput.value = localFormData.email;
+  messageInput.value = localFormData.message;
+};
+
+getLocalData();


### PR DESCRIPTION
This PR contains the following:
- Preserve form data in local storage (a change in any of the input fields, the data is saved to the local storage)
- When the user loads the page, if there is any data in the local storage the input fields are pre-filled with this data